### PR TITLE
feat(HU02): Integrar WorkExperienceSection en página de fixer

### DIFF
--- a/src/app/fixers/[id]/page.tsx
+++ b/src/app/fixers/[id]/page.tsx
@@ -2,7 +2,7 @@ import { getFixer } from "@/lib/api/fixer";
 import Link from "next/link";
 import FixerOwnerActions from "../components/FixerOwnerActions";
 import FixerSkillsList from "../components/FixerSkillsList";
-import WorkExperienceBridge from "../components/WorkExperienceBridge";
+import WorkExperienceBridge from "../../fixers/components/WorkExperienceBridge";
 
 type PageProps = { params: Promise<{ id: string }> };
 


### PR DESCRIPTION
- Corregir import de WorkExperienceBridge en fixers/[id]/page.tsx
- Componente Work Experience ahora se renderiza correctamente
- Muestra formularios de posiciones laborales y certificaciones
- Implementa edición solo para propietarios del perfil
- Estados vacíos informativos cuando no hay datos//Nicolas Jhair Zapata Sagardia-DPTINT3-HU2